### PR TITLE
build: pin ethers to latest 'master' hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,6 @@ dependencies = [
  "async-trait",
  "derive_builder",
  "ethers",
- "ethers-signers",
  "serde",
  "serde_json",
  "thiserror",
@@ -585,26 +584,22 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.8.7"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa6094030951ce3efad50fdba0efe088a93ffe05ec58c2f47cc60d9e90c715d"
+checksum = "9b913b49d2e008b23cffb802f29b8051feddf7b2cc37336ab9a7a410f832395a"
 dependencies = [
  "async-trait",
  "byteorder",
  "cfg-if",
- "futures",
  "getrandom",
  "hex",
  "hidapi-rusb",
  "js-sys",
- "lazy_static",
- "libc",
  "log",
- "matches",
  "nix",
- "serde",
- "tap",
+ "once_cell",
  "thiserror",
+ "tokio",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1097,8 +1092,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1113,8 +1107,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1125,8 +1118,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1144,8 +1136,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51258120c6b47ea9d9bec0d90f9e8af71c977fbefbef8213c91bfed385fe45eb"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1168,8 +1159,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1184,8 +1174,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1214,8 +1203,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbac2c890bdbe0f1b8e549a53b00e2c4c1de86bb077c1094d1f38cdf9381a56"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -1230,8 +1218,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1257,8 +1244,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1294,8 +1280,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb1b714e227bbd2d8c53528adb580b203009728b17d0d0e4119353aa9bc5532"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1317,8 +1302,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64f710586d147864cff66540a6d64518b9ff37d73ef827fee430538265b595f"
+source = "git+https://github.com/gakonst/ethers-rs.git?rev=88095ba47eb6a3507f0db1767353b387b27a6e98#88095ba47eb6a3507f0db1767353b387b27a6e98"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -2063,12 +2047,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md-5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,16 @@ version = "0.2.0"
 edition = "2021"
 description = "Crate for safe typecasting between ethers and alloy types"
 license = "CAL-1.0"
-homepage = "https://github.com/rainlanguage/rain.interpreter" 
+homepage = "https://github.com/rainlanguage/rain.interpreter"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethers = { version = "2.0", features = ["legacy"] }
-ethers-signers = { version = "2.0.8", features = ["ledger"] }
-alloy-primitives = {version = "0.5.4" , features = ["rand"]}
+ethers = { git = "https://github.com/gakonst/ethers-rs.git", rev = "88095ba47eb6a3507f0db1767353b387b27a6e98", features = [
+  "legacy",
+  "ledger",
+] }
+alloy-primitives = { version = "0.5.4", features = ["rand"] }
 alloy-sol-types = { version = "0.5.4" }
 anyhow = "1.0.70"
 tracing = "0.1.37"
@@ -26,7 +28,7 @@ serde = "1.0.195"
 tokio = { version = "1.28.0", features = ["full"] }
 
 [lints.clippy]
-all= "warn"
+all = "warn"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
-use ethers::signers::{HDPath, Ledger};
 use ethers::middleware::SignerMiddleware;
 use ethers::prelude::{Http, Provider};
+use ethers::signers::{HDPath, Ledger};
 
 pub struct LedgerClient {
     pub client: SignerMiddleware<Provider<Http>, Ledger>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
+use ethers::signers::{HDPath, Ledger};
 use ethers::middleware::SignerMiddleware;
 use ethers::prelude::{Http, Provider};
-use ethers_signers::{HDPath, Ledger};
 
 pub struct LedgerClient {
     pub client: SignerMiddleware<Provider<Http>, Ledger>,

--- a/src/transaction/write.rs
+++ b/src/transaction/write.rs
@@ -94,8 +94,8 @@ mod tests {
     use alloy_sol_types::sol;
     use ethers::core::rand::thread_rng;
     use ethers::providers::Provider;
+    use ethers::signers::LocalWallet;
     use ethers::types::{Bytes, H160};
-    use ethers_signers::LocalWallet;
     use tracing_subscriber;
     use tracing_subscriber::FmtSubscriber;
 


### PR DESCRIPTION
Pin ethers to latest commit on `master` so we get unreleased changes that include https://github.com/summa-tx/coins/issues/124 which will allow us to call the rust ledger client code via tauri.