### PR TITLE
revert: 4 confirmations by default

### DIFF
--- a/src/transaction/write.rs
+++ b/src/transaction/write.rs
@@ -44,7 +44,7 @@ impl<M: Middleware, S: Signer> WritableClient<M, S> {
 
         info!("Transaction submitted. Awaiting block confirmations...");
 
-        let tx_confirmation = pending_tx.confirmations(0).await?;
+        let tx_confirmation = pending_tx.confirmations(4).await?;
 
         let tx_receipt = match tx_confirmation {
             Some(receipt) => receipt,


### PR DESCRIPTION
Not sure if this was intentional, but do you think the default use should be to wait for at least 1 confirmation in the `write` function? And if you need to do something different, you can use the `write_pending`?