### PR TITLE
2024 01 21 write transaction status

### DIFF
--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,6 +1,8 @@
 mod mock_middleware;
 pub mod read;
 pub mod write;
+pub mod write_transaction;
 
 pub use read::*;
 pub use write::*;
+pub use write_transaction::*;

--- a/src/transaction/write_transaction.rs
+++ b/src/transaction/write_transaction.rs
@@ -88,3 +88,73 @@ impl<M: Middleware, S: Signer, C: SolCall + Clone, F: Fn(WriteTransactionStatus<
         (self.status_changed)(status);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::transaction::mock_middleware::{MockJsonRpcClient, MockMiddleware};
+    use crate::transaction::WriteContractParametersBuilder;
+
+    use super::*;
+    use alloy_primitives::{Address, U256};
+    use alloy_sol_types::sol;
+    use ethers::core::rand::thread_rng;
+    use ethers::providers::Provider;
+    use ethers::signers::LocalWallet;
+    use ethers::types::{Bytes, H160};
+    use tracing_subscriber;
+    use tracing_subscriber::FmtSubscriber;
+
+    sol! {
+       function foo(uint256 a, uint256 b) external view returns (Foo);
+
+        struct Foo {
+            uint256 bar;
+            address baz;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_transaction() -> anyhow::Result<()> {
+        // Create a mock transport
+        let mock_transport = MockJsonRpcClient::new();
+        // Create a Provider instance
+        let provider = Provider::new(mock_transport);
+        // Create a mock middleware
+        let mut mock_middleware = MockMiddleware::new(provider)?;
+        // Create a mock wallet
+        let wallet = LocalWallet::new(&mut thread_rng());
+
+        // Create a WriteContractParameters instance
+        let parameters = WriteContractParametersBuilder::default()
+            .call(fooCall {
+                a: U256::from(42), // these could be anything, the mock provider doesn't care
+                b: U256::from(10),
+            })
+            .address(Address::repeat_byte(0x22))
+            .build()?;
+
+        // Create a mock response
+        mock_middleware.assert_next_data(Bytes::from(parameters.call.abi_encode()));
+        mock_middleware.assert_next_to(H160::repeat_byte(0x22));
+
+        // Finally create a client SignerMiddleware instance
+        let client = SignerMiddleware::new(mock_middleware, wallet);
+
+        // Create a WritableClient instance with the mock client
+        WriteTransaction::new(client, parameters, 4, |_| {})
+            .execute()
+            .await?;
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn setup_tracing() {
+        let subscriber = FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("Failed to set tracing subscriber");
+    }
+}

--- a/src/transaction/write_transaction.rs
+++ b/src/transaction/write_transaction.rs
@@ -12,7 +12,6 @@ pub enum WriteTransactionStatus<C: SolCall> {
     PendingPrepare(WriteContractParameters<C>),
     PendingSign(TypedTransaction),
     PendingSend(Bytes),
-    PendingConfirm,
     Confirmed(TransactionReceipt),
 }
 
@@ -75,9 +74,10 @@ impl<M: Middleware, S: Signer, C: SolCall + Clone, F: Fn(WriteTransactionStatus<
                 .confirmations(self.confirmations.into())
                 .await
                 .map_err(|e| WritableClientError::WriteConfirmationError(e.to_string()))?
-                .ok_or(WritableClientError::WriteConfirmationError(
-                    "Transaction did not receive 4 confirmations".into(),
-                ))?;
+                .ok_or(WritableClientError::WriteConfirmationError(format!(
+                    "Transaction did not receive {} confirmations",
+                    self.confirmations,
+                )))?;
             self.update_status(WriteTransactionStatus::Confirmed(receipt));
         }
         Ok(())

--- a/src/transaction/write_transaction.rs
+++ b/src/transaction/write_transaction.rs
@@ -16,19 +16,26 @@ pub enum WriteTransactionStatus<C: SolCall> {
     Confirmed(TransactionReceipt),
 }
 
-pub struct WriteTransaction<M: Middleware, S: Signer, C: SolCall + Clone> {
+pub struct WriteTransaction<
+    M: Middleware,
+    S: Signer,
+    C: SolCall + Clone,
+    F: Fn(WriteTransactionStatus<C>) -> (),
+> {
     pub client: WritableClient<M, S>,
     pub status: WriteTransactionStatus<C>,
     pub confirmations: u8,
-    pub status_changed: fn(WriteTransactionStatus<C>) -> (),
+    pub status_changed: F,
 }
 
-impl<M: Middleware, S: Signer, C: SolCall + Clone> WriteTransaction<M, S, C> {
+impl<M: Middleware, S: Signer, C: SolCall + Clone, F: Fn(WriteTransactionStatus<C>) -> ()>
+    WriteTransaction<M, S, C, F>
+{
     pub fn new(
         client: SignerMiddleware<M, S>,
         parameters: WriteContractParameters<C>,
         confirmations: u8,
-        status_changed: fn(WriteTransactionStatus<C>) -> (),
+        status_changed: F,
     ) -> Self {
         Self {
             client: WritableClient::new(client),


### PR DESCRIPTION
I'd like to use a pattern like this for wrapping transactions, so that I can get status updates on the transaction's progress via a closure and then handle them differently for each UI. 

This PR creates a `WriteTransaction` struct that wraps a call and parameters for a single transaction. It goes through each step of the transaction process discretely: preparing, signing, sending, confirming. After each step completes it calls the status update closure.

I feel like it could potentially replace the functions `write` and `write_pending` in the `WritableClient`, or replace it entirely, but I didn't want to go that far without checking in with you @hardyjosh 

This lets us support a UI to clearly show the ongoing progress of a pending transaction as it progresses, including when it is waiting for user action.

I'm sure it could have been implemented better - would love to hear your thoughts @thedavidmeister. I feel like its leaning towards a state machine, but I didn't quite go all the way.