### PR TITLE
Adding multiple rpc url support for ReadableClient

### DIFF
--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -113,7 +113,7 @@ impl<T: SolCall> Multicall<T> {
 mod tests {
     use super::*;
     use crate::{multicall::IMulticall3::Result as MulticallResult, rpc::Response};
-    use alloy::{hex::encode_prefixed, primitives::B256, sol_types::SolValue};
+    use alloy::{hex::encode_prefixed, sol_types::SolValue};
     use httpmock::{Method::POST, MockServer};
     use serde_json::{from_str, Value};
 
@@ -189,7 +189,7 @@ mod tests {
             );
         });
 
-        let provider = ReadableClient::new_from_url(rpc_server.url("/rpc"))?;
+        let provider = ReadableClient::new_from_urls(vec![rpc_server.url("/rpc")])?;
         let result = multicall.read(&provider, None, None, None).await?;
         let mut result_symbols = vec![];
         for res in result {

--- a/src/transaction/read.rs
+++ b/src/transaction/read.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::request_shim::{AlloyTransactionRequest, TransactionRequestShim};
 use crate::{alloy_u64_to_ethers, ethers_u256_to_alloy};
 use alloy::primitives::{Address, U256, U64};
@@ -25,6 +26,10 @@ pub enum ReadableClientError {
     AbiDecodeFailedErrors(#[from] AbiDecodeFailedErrors),
     #[error(transparent)]
     AbiDecodedErrorType(#[from] AbiDecodedErrorType),
+    #[error("all providers failed to handle the request: {0:?}")]
+    AllProvidersFailed(HashMap<String, ReadableClientError>),
+    #[error("rpc provider {0} failed to handle the request: {1}")]
+    RpcProviderFailed(String, String),
 }
 
 #[derive(Builder)]
@@ -38,22 +43,32 @@ pub struct ReadContractParameters<C: SolCall> {
 }
 
 #[derive(Clone)]
-pub struct ReadableClient<P: JsonRpcClient>(Provider<P>);
+pub struct ReadableClient<P: JsonRpcClient> {
+    providers: HashMap<String, Provider<P>>,
+}
 
 pub type ReadableClientHttp = ReadableClient<Http>;
 
 impl ReadableClient<Http> {
-    pub fn new_from_url(url: String) -> Result<Self, ReadableClientError> {
-        let provider = Provider::<Http>::try_from(url)
-            .map_err(|err| ReadableClientError::CreateReadableClientHttpError(err.to_string()))?;
-        Ok(Self(provider))
+    pub fn new_from_urls(urls: Vec<String>) -> Result<Self, ReadableClientError> {
+        let providers: HashMap<String, _> = urls
+            .into_iter()
+            .filter_map(|url| Provider::<Http>::try_from(url.clone()).ok().map(|provider| (url, provider)))
+            .collect();
+
+        if providers.is_empty() {
+            Err(ReadableClientError::CreateReadableClientHttpError(
+                "No valid providers could be created from the given URLs.".to_string(),
+            ))
+        } else {
+            Ok(Self { providers })
+        }
     }
 }
 
 impl<P: JsonRpcClient> ReadableClient<P> {
-    // Create a new ReadableClient instance, passing a client
-    pub fn new(client: Provider<P>) -> Self {
-        Self(client)
+    pub fn new(providers: HashMap<String, Provider<P>>) -> Self {
+        Self { providers }
     }
 
     // Executes a read function on a contract.
@@ -68,50 +83,79 @@ impl<P: JsonRpcClient> ReadableClient<P> {
             .with_data(Some(data))
             .with_gas(parameters.gas);
 
-        let res = self
-            .0
-            .call(
-                &TypedTransaction::Eip1559(transaction_request.to_eip1559()),
-                parameters.block_number.map(|val| {
-                    ethers::types::BlockId::Number(ethers::types::BlockNumber::Number(
-                        alloy_u64_to_ethers(val),
-                    ))
-                }),
-            )
-            .await;
+        let mut errors: HashMap<String, ReadableClientError> = HashMap::new();
 
-        let res = match res {
-            Ok(res) => res,
-            Err(err) => {
-                let err = AbiDecodedErrorType::try_from_provider_error(err).await?;
-                return Err(ReadableClientError::AbiDecodedErrorType(err));
+        for (url, provider) in &self.providers {
+            let typed_tx = TypedTransaction::Eip1559(transaction_request.to_eip1559());
+            let block_id = parameters.block_number.map(|val| {
+                ethers::types::BlockId::Number(ethers::types::BlockNumber::Number(
+                    alloy_u64_to_ethers(val),
+                ))
+            });
+
+            match provider.call(&typed_tx, block_id).await {
+                Ok(res) => {
+                    return C::abi_decode_returns(res.to_vec().as_slice(), true)
+                        .map_err(|err| ReadableClientError::ReadDecodeReturnError(err.to_string()));
+                }
+                Err(provider_err) => {
+                    match AbiDecodedErrorType::try_from_provider_error(provider_err).await {
+                        Ok(decoded_err) => {
+                            errors.insert(url.clone(), ReadableClientError::AbiDecodedErrorType(decoded_err));
+                        }
+                        Err(decode_failed_err) => {
+                            errors.insert(url.clone(), ReadableClientError::AbiDecodeFailedErrors(decode_failed_err));
+                        }
+                    }
+                }
             }
-        };
+        }
 
-        let return_typed = C::abi_decode_returns(res.to_vec().as_slice(), true)
-            .map_err(|err| ReadableClientError::ReadDecodeReturnError(err.to_string()))?;
-
-        Ok(return_typed)
+        if errors.is_empty() {
+            Err(ReadableClientError::CreateReadableClientHttpError(
+                "No providers were available to handle the request.".to_string(),
+            ))
+        } else {
+            Err(ReadableClientError::AllProvidersFailed(errors))
+        }
     }
 
     pub async fn get_chainid(&self) -> Result<U256, ReadableClientError> {
-        let chainid = self
-            .0
-            .get_chainid()
-            .await
-            .map_err(|err| ReadableClientError::ReadChainIdError(err.to_string()))?;
+        let mut errors: HashMap<String, ReadableClientError> = HashMap::new();
 
-        Ok(ethers_u256_to_alloy(chainid))
+        for (url, provider) in &self.providers {
+            let res = provider
+                .get_chainid()
+                .await
+                .map_err(|err| ReadableClientError::ReadChainIdError(err.to_string()));
+
+            if let Ok(chainid) = res {
+                return Ok(ethers_u256_to_alloy(chainid));
+            } else {
+                errors.insert(url.clone(), res.err().unwrap());
+            }
+        }
+
+        Err(ReadableClientError::AllProvidersFailed(errors))
     }
 
     pub async fn get_block_number(&self) -> Result<u64, ReadableClientError> {
-        let block_number = self
-            .0
-            .get_block_number()
-            .await
-            .map_err(|err| ReadableClientError::ReadBlockNumberError(err.to_string()))?;
+        let mut errors: HashMap<String, ReadableClientError> = HashMap::new();
 
-        Ok(block_number.as_u64())
+        for (url, provider) in &self.providers {
+            let res = provider
+                .get_block_number()
+                .await
+                .map_err(|err| ReadableClientError::ReadBlockNumberError(err.to_string()));
+
+            if let Ok(block_number) = res {
+                return Ok(block_number.as_u64());
+            } else {
+                errors.insert(url.clone(), res.err().unwrap());
+            }
+        }
+
+        Err(ReadableClientError::AllProvidersFailed(errors))
     }
 }
 
@@ -183,7 +227,7 @@ mod tests {
         let client = Provider::new(mock_provider);
 
         // Create a ReadableClient instance with the mock provider
-        let read_contract = ReadableClient::new(client);
+        let read_contract = ReadableClient::new(HashMap::from([("url".to_string(), client)]));
 
         // Create a ReadContractParameters instance
         let parameters = ReadContractParametersBuilder::default()
@@ -222,7 +266,7 @@ mod tests {
         let client = Provider::new(mock_provider);
 
         // Create a ReadableClient instance with the mock provider
-        let read_contract = ReadableClient::new(client);
+        let read_contract = ReadableClient::new(HashMap::from([("url".to_string(), client)]));
         let res = read_contract.get_chainid().await.unwrap();
 
         assert_eq!(res, U256::from(5));
@@ -245,7 +289,7 @@ mod tests {
         let client = Provider::new(mock_provider);
 
         // Create a ReadableClient instance with the mock provider
-        let read_contract = ReadableClient::new(client);
+        let read_contract = ReadableClient::new(HashMap::from([("url".to_string(), client)]));
         let res = read_contract.get_block_number().await.unwrap();
 
         assert_eq!(res, 6_u64);
@@ -272,7 +316,7 @@ mod tests {
         let client = Provider::new(mock_provider);
 
         // Create a ReadableClient instance with the mock provider
-        let read_contract = ReadableClient::new(client);
+        let read_contract = ReadableClient::new(HashMap::from([("url".to_string(), client)]));
 
         // Create a ReadContractParameters instance
         let parameters = ReadContractParametersBuilder::default()
@@ -291,16 +335,335 @@ mod tests {
         let err = result.err().unwrap();
 
         match err {
-            ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Known {
-                name,
-                args,
-                sig,
-                data,
-            }) => {
-                assert_eq!(name, "UnexpectedOperandValue");
-                assert_eq!(args, vec![] as Vec<String>);
-                assert_eq!(sig, "UnexpectedOperandValue()");
-                assert_eq!(data, vec![26, 198, 105, 8]);
+            ReadableClientError::AllProvidersFailed(errors) => {
+                assert_eq!(errors.len(), 1);
+
+                assert!(errors.contains_key("url"));
+                match errors.get("url") {
+                    Some(ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Known {
+                        name,
+                        args,
+                        sig,
+                        data,
+                    })) => {
+                        assert_eq!(name, "UnexpectedOperandValue");
+                        assert_eq!(args, &(vec![] as Vec<String>));
+                        assert_eq!(sig, "UnexpectedOperandValue()");
+                        assert_eq!(data, &vec![26, 198, 105, 8]);
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+            }
+            _ => panic!("unexpected error type"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_read() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+        let mock_provider3 = MockProvider::new();
+
+        let foo_response = json!("0x000000000000000000000000000000000000000000000000000000000000002a0000000000000000000000001111111111111111111111111111111111111111");
+        let mock_response = MockResponse::Value(foo_response);
+        let mock_error = MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        });
+
+        mock_provider1.push_response(mock_error.clone());
+        mock_provider2.push_response(mock_error.clone());
+        mock_provider3.push_response(mock_response);
+
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+        let client3 = Provider::new(mock_provider3);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url1".to_string(), client1),
+            ("url2".to_string(), client2),
+            ("url3".to_string(), client3),
+        ]));
+
+        let parameters = ReadContractParametersBuilder::default()
+        .call(fooCall {
+            a: U256::from(42), // these could be anything, the mock provider doesn't care
+            b: U256::from(10),
+        })
+        .address(Address::repeat_byte(0x22))
+        .build()?;
+        let result = read_contract.read(parameters).await?;
+            
+        let bar = result._0.bar;
+        let baz = result._0.baz;
+        assert_eq!(bar, U256::from(42));
+        assert_eq!(baz, Address::repeat_byte(0x11));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_read_error() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+        let mock_provider3 = MockProvider::new();
+        let mock_provider4 = MockProvider::new();
+
+        mock_provider1.push_response(MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        }));
+        mock_provider2.push_response(MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: Some(json!(encode(&vec![26, 198, 105, 8]))),
+            message: "some other error".to_string(),
+        }));
+        mock_provider3.push_response(MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: Some(json!({"error": "some other error"})),
+            message: "some other error".to_string(),
+        }));
+        mock_provider4.push_response(MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: Some(json!(&vec![1])),
+            message: "some other error".to_string(),
+        }));
+
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+        let client3 = Provider::new(mock_provider3);
+        let client4 = Provider::new(mock_provider4);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url4".to_string(), client1),
+            ("url5".to_string(), client2),
+            ("url6".to_string(), client3),
+            ("url7".to_string(), client4),
+        ]));
+
+        let parameters = ReadContractParametersBuilder::default()
+        .call(fooCall {
+            a: U256::from(42), // these could be anything, the mock provider doesn't care
+            b: U256::from(10),
+        })
+        .address(Address::repeat_byte(0x22))
+        .build()?;
+
+        let res = read_contract.read(parameters).await;
+        let err = res.err().unwrap();
+        match err {
+            ReadableClientError::AllProvidersFailed(errors) => {
+                assert_eq!(errors.len(), 4);
+                
+                assert!(errors.contains_key("url4"));
+                match errors.get("url4") {
+                    Some(ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Unknown(data))) => {
+                        assert_eq!(data, &Vec::<u8>::new());
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+
+                assert!(errors.contains_key("url5"));
+                match errors.get("url5") {
+                    Some(ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Known {
+                        name,
+                        args,
+                        sig,
+                        data,
+                    })) => {
+                        assert_eq!(name, "UnexpectedOperandValue");
+                        assert_eq!(args, &(vec![] as Vec<String>));
+                        assert_eq!(sig, "UnexpectedOperandValue()");
+                        assert_eq!(data, &vec![26, 198, 105, 8]);
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+
+                assert!(errors.contains_key("url6"));
+                match errors.get("url6") {
+                    Some(ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Unknown(data))) => {
+                        assert_eq!(data, &Vec::<u8>::new());
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+
+                assert!(errors.contains_key("url7"));
+                match errors.get("url7") {
+                    Some(ReadableClientError::AbiDecodedErrorType(AbiDecodedErrorType::Unknown(data))) => {
+                        assert_eq!(data, &Vec::<u8>::new());
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+            }
+            _ => panic!("unexpected error type"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_get_block_number() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+        let mock_provider3 = MockProvider::new();
+
+        let foo_response = json!("0x0000006");
+        let mock_response = MockResponse::Value(foo_response);
+        let mock_error = MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        });
+
+        mock_provider1.push_response(mock_error.clone());
+        mock_provider2.push_response(mock_error.clone());
+        mock_provider3.push_response(mock_response);
+
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+        let client3 = Provider::new(mock_provider3);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url1".to_string(), client1),
+            ("url2".to_string(), client2),
+            ("url3".to_string(), client3),
+        ]));
+            
+        let res = read_contract.get_block_number().await.unwrap();
+        assert_eq!(res, 6_u64);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_get_block_number_error() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+
+        let mock_error = MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        });
+        mock_provider1.push_response(mock_error.clone());
+        mock_provider2.push_response(mock_error.clone());
+        
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url1".to_string(), client1),
+            ("url2".to_string(), client2),
+        ]));
+
+        let res = read_contract.get_block_number().await;
+        let err = res.err().unwrap();
+        match err {
+            ReadableClientError::AllProvidersFailed(errors) => {
+                assert_eq!(errors.len(), 2);
+
+                assert!(errors.contains_key("url1"));
+                match errors.get("url1") {
+                    Some(ReadableClientError::ReadBlockNumberError(error)) => {
+                        assert_eq!(error, "JSON-RPC error: (code: 3, message: execution reverted, data: None)");
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+
+                assert!(errors.contains_key("url2"));
+                match errors.get("url2") {
+                    Some(ReadableClientError::ReadBlockNumberError(error)) => {
+                        assert_eq!(error, "JSON-RPC error: (code: 3, message: execution reverted, data: None)");
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+            }
+            _ => panic!("unexpected error type"),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_get_chainid() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+        let mock_provider3 = MockProvider::new();
+
+        let foo_response = json!("0x00000005");
+        let mock_response = MockResponse::Value(foo_response);
+        let mock_error = MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        });
+
+        mock_provider1.push_response(mock_error.clone());
+        mock_provider2.push_response(mock_error.clone());
+        mock_provider3.push_response(mock_response);
+
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+        let client3 = Provider::new(mock_provider3);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url1".to_string(), client1),
+            ("url2".to_string(), client2),
+            ("url3".to_string(), client3),
+        ]));
+            
+        let res = read_contract.get_chainid().await.unwrap();
+        assert_eq!(res, U256::from(5));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_providers_get_chainid_error() -> anyhow::Result<()> {
+        let mock_provider1 = MockProvider::new();
+        let mock_provider2 = MockProvider::new();
+
+        let mock_error = MockResponse::Error(JsonRpcError {
+            code: 3,
+            data: None,
+            message: "execution reverted".to_string(),
+        });
+        mock_provider1.push_response(mock_error.clone());
+        mock_provider2.push_response(mock_error.clone());
+        
+        let client1 = Provider::new(mock_provider1);
+        let client2 = Provider::new(mock_provider2);
+
+        let read_contract = ReadableClient::new(HashMap::from([
+            ("url1".to_string(), client1),
+            ("url2".to_string(), client2),
+        ]));
+
+        let res = read_contract.get_chainid().await;
+        let err = res.err().unwrap();
+        match err {
+            ReadableClientError::AllProvidersFailed(errors) => {
+                assert_eq!(errors.len(), 2);
+
+                assert!(errors.contains_key("url1"));
+                match errors.get("url1") {
+                    Some(ReadableClientError::ReadChainIdError(error)) => {
+                        assert_eq!(error, "JSON-RPC error: (code: 3, message: execution reverted, data: None)");
+                    }
+                    _ => panic!("unexpected error type"),
+                }
+
+                assert!(errors.contains_key("url2"));
+                match errors.get("url2") {
+                    Some(ReadableClientError::ReadChainIdError(error)) => {
+                        assert_eq!(error, "JSON-RPC error: (code: 3, message: execution reverted, data: None)");
+                    }
+                    _ => panic!("unexpected error type"),
+                }
             }
             _ => panic!("unexpected error type"),
         }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

During any read calls, if there is an error coming from the RPC, the flow stops. We need a way to try multiple rpcs for the same call if it fails.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Change single provider to be a HashMap that maps rpc urls to providers
- Update read, chainid and block number functions with new logic
- Update tests

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- ~[ ] included screenshots (if this involves a front-end change)~
