### PR TITLE
Re-add `new_from_url` function for backwards support

### DIFF
--- a/src/transaction/read.rs
+++ b/src/transaction/read.rs
@@ -50,6 +50,14 @@ pub struct ReadableClient<P: JsonRpcClient> {
 pub type ReadableClientHttp = ReadableClient<Http>;
 
 impl ReadableClient<Http> {
+    pub fn new_from_url(url: String) -> Result<Self, ReadableClientError> {
+        let provider = Provider::<Http>::try_from(url.clone())
+            .map_err(|err| ReadableClientError::CreateReadableClientHttpError(err.to_string()))?;
+        Ok(Self {
+            providers: HashMap::from([(url, provider)]),
+        })
+    }
+
     pub fn new_from_urls(urls: Vec<String>) -> Result<Self, ReadableClientError> {
         let providers: HashMap<String, _> = urls
             .into_iter()


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create a client instance using a single URL, improving flexibility for users who wish to connect to one provider at a time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->