### PR TITLE
Update Rust/rainix and rain.error

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  URL=https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc
+  HASH=sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM=
+  source_url "$URL" "$HASH"
+fi
+
+watch_file flake.lock
+watch_file flake.nix
+
+use flake . --verbose --show-trace

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -1,6 +1,10 @@
 name: Rainix CI
 on: [push]
 
+concurrency:
+  group: ${{ github.ref }}-rainix
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   standard-tests:
     strategy:
@@ -21,9 +25,19 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
 
       - run: nix develop -c rainix-rs-prelude
       - name: Run ${{ matrix.task }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.direnv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,12 @@ version = "0.2.0"
 edition = "2021"
 description = "Crate for safe typecasting between ethers and alloy types"
 license = "CAL-1.0"
-homepage = "https://github.com/rainlanguage/rain.interpreter"
+homepage = "https://github.com/rainlanguage/alloy-ethers-typecast"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethers = { version = "2.0.14", features = [
-  "legacy",
-  "ledger",
-] }
+ethers = { version = "2.0.14", features = ["legacy", "ledger"] }
 alloy = { version = "0.1.4", features = ["rand", "sol-types"] }
 once_cell = "1.17.1"
 reqwest = { version = "0.11.17", features = ["json"] }
@@ -23,7 +20,7 @@ async-trait = "0.1.77"
 thiserror = "1.0.56"
 tracing-subscriber = "0.3.18"
 serde = "1.0.195"
-rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "fa0cc05a8dbf0f167a2392255a8b509309e9da46" }
+rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error", rev = "63410e90183de44a804f3d10b82151b55af4c7d8" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.11", features = ["js", "js-sys"] }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -56,29 +56,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -93,16 +75,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714727549,
-        "narHash": "sha256-CWXRTxxcgMfQubJugpeg3yVWIfm70MYTtgaKWKgD60U=",
+        "lastModified": 1741023058,
+        "narHash": "sha256-LSd/8CBlpDLjci5ANFJjP0w+dGdY/mqKsyUfhjGwnfs=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "47cf189ec395eda4b3e0623179d1075c8027ca97",
+        "rev": "66becfe20b7e688b8f2e5774609c4436cf202ba0",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
-        "ref": "monthly",
         "repo": "foundry.nix",
         "type": "github"
       }
@@ -123,11 +104,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714764285,
-        "narHash": "sha256-oeevp27kMeDjKdxaTyXyS14TLjJrpJhXp7UVEUdYqYs=",
+        "lastModified": 1747828570,
+        "narHash": "sha256-tv8R4Z/69GC8zogsb5TNDRj5tkhMeHpyYIzRl1cJigo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d121ce778b2609ae9e749a711295ffca013a82c4",
+        "rev": "040a62f13f40879a05578a66dd4ae0d284c55a5b",
         "type": "github"
       },
       "original": {
@@ -138,11 +119,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -154,11 +135,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708564076,
-        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {
@@ -177,16 +158,17 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1714897026,
-        "narHash": "sha256-ugsjTrdi0tIqTzym6TVIoDRTGq68KM3Rfb+6lWcgF30=",
+        "lastModified": 1747832348,
+        "narHash": "sha256-5t7vMuMk5zZBwaxQudSh0ohKx8SFftlrTKXVojNCqSk=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "7d69e91d5232fd191bcecf5d62cfa4e7339d5a40",
+        "rev": "4e87c16f3abcb4e9e309609f452669f5a85bb558",
         "type": "github"
       },
       "original": {
         "owner": "rainprotocol",
         "repo": "rainix",
+        "rev": "4e87c16f3abcb4e9e309609f452669f5a85bb558",
         "type": "github"
       }
     },
@@ -198,15 +180,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1714702555,
-        "narHash": "sha256-/NoUbE5S5xpK1FU3nlHhQ/tL126+JcisXdzy3Ng4pDU=",
+        "lastModified": 1747795013,
+        "narHash": "sha256-c7i0xJ+xFhgjO9SWHYu5dF/7lq63RPDvwKAdjc6VCE4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7f0e3ef7b7fbed78e12e5100851175d28af4b7c6",
+        "rev": "6b1cf12374361859242a562e1933a7930649131a",
         "type": "github"
       },
       "original": {
@@ -217,21 +198,34 @@
     },
     "solc": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_4",
+        "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1711538161,
-        "narHash": "sha256-rETVdEIQ2PyEcNgzXXFSiYAYl0koCeGDIWp9XYBTxoQ=",
+        "lastModified": 1742758229,
+        "narHash": "sha256-FrU9rhab/0vOjjeFoQF+Ej43zRLv3enUIYjgLrH3Gd8=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "a995838545a7383a0b37776e969743b1346d5479",
+        "rev": "6885b61bac89da19a6e3c70b89fdd592e2cef884",
         "type": "github"
       },
       "original": {
         "owner": "hellwolf",
         "repo": "solc.nix",
         "type": "github"
+      }
+    },
+    "solc-macos-amd64-list-json": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-U5ckttxwKO13gIKggel6iybG5oTDbSidPR5nH3Gs+kY=",
+        "type": "file",
+        "url": "https://github.com/ethereum/solc-bin/raw/30a3695/macosx-amd64/list.json"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://github.com/ethereum/solc-bin/raw/30a3695/macosx-amd64/list.json"
       }
     },
     "systems": {
@@ -265,21 +259,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -158,17 +158,16 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1747832348,
-        "narHash": "sha256-5t7vMuMk5zZBwaxQudSh0ohKx8SFftlrTKXVojNCqSk=",
+        "lastModified": 1748346550,
+        "narHash": "sha256-Rlaj/hHHACo0blFKane6/arqIXWUCGe/sCNgqX8VfZ8=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "4e87c16f3abcb4e9e309609f452669f5a85bb558",
+        "rev": "a1a5c321f356cb5006d16dd2d1a2242c183b7e96",
         "type": "github"
       },
       "original": {
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "4e87c16f3abcb4e9e309609f452669f5a85bb558",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "Flake for development workflows.";
 
   inputs = {
-    rainix.url =
-      "github:rainprotocol/rainix?rev=4e87c16f3abcb4e9e309609f452669f5a85bb558";
+    rainix.url = "github:rainprotocol/rainix";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,14 @@
   description = "Flake for development workflows.";
 
   inputs = {
-    rainix.url = "github:rainprotocol/rainix";
+    rainix.url =
+      "github:rainprotocol/rainix?rev=4e87c16f3abcb4e9e309609f452669f5a85bb558";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {self, flake-utils, rainix }:
-    flake-utils.lib.eachDefaultSystem (system:
-      {
-        packages = rainix.packages.${system};
-        devShells = rainix.devShells.${system};
-      }
-    );
+  outputs = { self, flake-utils, rainix }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      packages = rainix.packages.${system};
+      devShells = rainix.devShells.${system};
+    });
 }

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -99,11 +99,13 @@ impl<T: SolCall> Multicall<T> {
             .returnData
             .iter()
             .map(|v| {
-                v.success
-                    .then(|| Ok(T::abi_decode_returns(&v.returnData, true).map_err(Into::into)))
-                    .unwrap_or(Err(MulticallError::MulticallCallItemFailed(
+                if v.success {
+                    Ok(T::abi_decode_returns(&v.returnData, true).map_err(Into::into))
+                } else {
+                    Err(MulticallError::MulticallCallItemFailed(
                         v.returnData.clone().into(),
-                    )))
+                    ))
+                }
             })
             .collect::<Vec<Result<Result<T::Return, MulticallError>, MulticallError>>>())
     }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

We need the latest version of alloy to upgrade to the new versions of the interpreter/orderbook, we need a newer version of Rust to upgrade to the latest alloy, and we need to bump up rainix to upgrade to the latest version of Rust.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR upgrades `rainix`, Rust version, and `rain.error`. `alloy` is upgraded in #46 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
